### PR TITLE
Added a couple of modules from MTM, System80 & Dave Hamara

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ An awesome list of open source synthesizer projects.
 
   - Sequencer
     - [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-    -[Turing Machine Mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([Music Thing Modular - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/)) 
+    - [Turing Machine Mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([Music Thing Modular - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
+
 
   - Envelope Generator / ADSR
     - [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ An awesome list of open source synthesizer projects.
 ### Audio Effects
 
 ### Other/Utility
+- Eurorack
+  - Mixer
+    - [Tripple Attenuverter Mixer v2](https://github.com/ishkabbible/Triple_Attenuverter_Mixer_v2) : Three precision attenuators/attenuverters
 
 ### Full Voice
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ An awesome list of open source synthesizer projects.
 ### Audio Effects
 
 ### Other/Utility
+
 -   Eurorack
-  - Mixer
+
+    - Mixer
+
     - [Trippe Attenuverter Mixer v2](https://github.com/ishkabbible/Triple_Attenuverter_Mixer_v2) : TAM is a three precision attenuator/attenuverter.
 ### Full Voice
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ An awesome list of open source synthesizer projects.
 
   - Sequencer
     - [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
+    -
     [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
   - Envelope Generator / ADSR
     - [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ An awesome list of open source synthesizer projects.
 
 ### Audio Processing
 
+- Eurorack
+
+  - Filter
+    - [Jove](https://github.com/minisystem/JOVE) : Roland Jupiter 6 inspired multimode filter in 14HP Eurorack format ([System80 - Jove](http://system80.net/product/jove/))
+
 ### Modulation Source
 
 - Eurorack

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ An awesome list of open source synthesizer projects.
 
 ### Other/Utility
 - Eurorack
+
   - Mixer
+
     - [Tripple Attenuverter Mixer v2](https://github.com/ishkabbible/Triple_Attenuverter_Mixer_v2) : Three precision attenuators/attenuverters
 
 ### Full Voice

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An awesome list of open source synthesizer projects.
 
     -   Sequencer
         -   [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-        -   [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))   
+        -   [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
 
     -   Envelope Generator / ADSR
         -   [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
@@ -46,6 +46,11 @@ An awesome list of open source synthesizer projects.
 
 ### Other/Utility
 
+-   Eurorack
+
+    -   Mixer
+
+        - [Trippe Attenuverter Mixer v2](https://github.com/ishkabbible/Triple_Attenuverter_Mixer_v2) : TAM is a three precision attenuator/attenuverter.
 ### Full Voice
 
 ## Standalone

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ An awesome list of open source synthesizer projects.
 
     -   Sequencer
         -   [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-        -   [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
+        -   [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))   
+
     -   Envelope Generator / ADSR
         -   [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ An awesome list of open source synthesizer projects.
     - [Turing Machine Mk2 expander - Volts](https://github.com/TomWhitwell/Volts) : Expander for the Turing Machine Mk2 [(Music Thing Modular - Volts Expander](http://www.musicthing.co.uk/)
     - [Turing Machine Mk2 expander - Pulses](https://github.com/TomWhitwell/Turing-Pulse-Expander) : Expander for the Turing Machine Mk2 ([Music Thing Modular - Pulses Expander](http://www.musicthing.co.uk/))
     - [Turing Macine Mk2 expander - Voltages](https://github.com/TomWhitwell/Voltages-Expander) : Expander for the Turing Machine Mk2 ([Music Thing Modular - Voltages](http://www.musicthing.co.uk/))
+    - [Mikrophonie](https://github.com/TomWhitwell/Mikrophonie) : 4hp contact mic pre-amp module ([Music Thing Modular - Mikrophonie](http://www.musicthing.co.uk/))
 
 
   - Envelope Generator / ADSR

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ An awesome list of open source synthesizer projects.
 
   - Sequencer
     - [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-    - [Turing Machine Mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([Music Thing Modular - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
+    - [Turing Machine Mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([Music Thing Modular - Turing Machine Mk2](http://www.musicthing.co.uk/))
+    - [Turing Machine Mk2 expander - Volts](https://github.com/TomWhitwell/Volts) : Expander for the Turing Machine Mk2 [(Music Thing Modular - Volts Expander](http://www.musicthing.co.uk/)
+    - [Turing Machine Mk2 expander - Pulses](https://github.com/TomWhitwell/Turing-Pulse-Expander) : Expander for the Turing Machine Mk2 ([Music Thing Modular - Pulses Expander](http://www.musicthing.co.uk/))
+    - [Turing Macine Mk2 expander - Voltages](https://github.com/TomWhitwell/Voltages-Expander) : Expander for the Turing Machine Mk2 ([Music Thing Modular - Voltages](http://www.musicthing.co.uk/))
 
 
   - Envelope Generator / ADSR

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ An awesome list of open source synthesizer projects.
 
   - Sequencer
     - [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-    -
     [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
   - Envelope Generator / ADSR
     - [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ An awesome list of open source synthesizer projects.
     - [Turing Machine Mk2 expander - Volts](https://github.com/TomWhitwell/Volts) : Expander for the Turing Machine Mk2 [(Music Thing Modular - Volts Expander](http://www.musicthing.co.uk/)
     - [Turing Machine Mk2 expander - Pulses](https://github.com/TomWhitwell/Turing-Pulse-Expander) : Expander for the Turing Machine Mk2 ([Music Thing Modular - Pulses Expander](http://www.musicthing.co.uk/))
     - [Turing Macine Mk2 expander - Voltages](https://github.com/TomWhitwell/Voltages-Expander) : Expander for the Turing Machine Mk2 ([Music Thing Modular - Voltages](http://www.musicthing.co.uk/))
-    - [Mikrophonie](https://github.com/TomWhitwell/Mikrophonie) : 4hp contact mic pre-amp module ([Music Thing Modular - Mikrophonie](http://www.musicthing.co.uk/))
 
 
   - Envelope Generator / ADSR
@@ -60,6 +59,9 @@ An awesome list of open source synthesizer projects.
   - Mixer
 
     - [Tripple Attenuverter Mixer v2](https://github.com/ishkabbible/Triple_Attenuverter_Mixer_v2) : Three precision attenuators/attenuverters
+    -
+  - Amplifier
+    - [Mikrophonie](https://github.com/TomWhitwell/Mikrophonie) : 4hp contact mic pre-amp module ([Music Thing Modular - Mikrophonie](http://www.musicthing.co.uk/))
 
 ### Full Voice
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ An awesome list of open source synthesizer projects.
     - [Swirls](https://github.com/ElectricMist/Swirls) : Tides in an 8hp footprint
     - [Tides](https://github.com/pichenettes/eurorack/tree/master/tides) : Tidal modulator ([Mutable Instruments - Tides](https://mutable-instruments.net/modules/tides/))
     - [Wobbler](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Advanced LFO ([TINRS - Wobbler](http://www2.thisisnotrocketscience.nl/eurorack/wobbler/))
-  
+
   - Sequencer
     - [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-    
+    -
+    [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
   - Envelope Generator / ADSR
     - [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
 
@@ -49,4 +50,3 @@ An awesome list of open source synthesizer projects.
 
 ## Standalone
 - [The Klangorium](https://github.com/hexagon5un/klangorium) - Hardware and tutorials for the Hackaday / Logic Noise Klangorium demo board
-

--- a/README.md
+++ b/README.md
@@ -27,16 +27,15 @@ An awesome list of open source synthesizer projects.
 
     -   LFO
 
-        -   [Swirls](https://github.com/ElectricMist/Swirls) : Tides in an 8hp footprint
-        -   [Tides](https://github.com/pichenettes/eurorack/tree/master/tides) : Tidal modulator ([Mutable Instruments - Tides](https://mutable-instruments.net/modules/tides/))
-        -   [Wobbler](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Advanced LFO ([TINRS - Wobbler](http://www2.thisisnotrocketscience.nl/eurorack/wobbler/))
+    -   [Swirls](https://github.com/ElectricMist/Swirls) : Tides in an 8hp footprint        -   [Tides](https://github.com/pichenettes/eurorack/tree/master/tides) : Tidal modulator ([Mutable Instruments - Tides](https://mutable-instruments.net/modules/tides/))
+    -   [Wobbler](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Advanced LFO ([TINRS - Wobbler](http://www2.thisisnotrocketscience.nl/eurorack/wobbler/))
 
     -   Sequencer
-        -   [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-        -   [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
+    -   [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
+    -   [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
 
     -   Envelope Generator / ADSR
-        -   [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
+    -   [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
 
 ### Modulation Processing
 
@@ -45,12 +44,9 @@ An awesome list of open source synthesizer projects.
 ### Audio Effects
 
 ### Other/Utility
-
 -   Eurorack
-
-    -   Mixer
-
-        - [Trippe Attenuverter Mixer v2](https://github.com/ishkabbible/Triple_Attenuverter_Mixer_v2) : TAM is a three precision attenuator/attenuverter.
+  - Mixer
+    - [Trippe Attenuverter Mixer v2](https://github.com/ishkabbible/Triple_Attenuverter_Mixer_v2) : TAM is a three precision attenuator/attenuverter.
 ### Full Voice
 
 ## Standalone

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ An awesome list of open source synthesizer projects.
 
     -   Sequencer
         -   [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-        -
-        [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
+        -   [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
     -   Envelope Generator / ADSR
         -   [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ An awesome list of open source synthesizer projects.
 
 ## Contents
 
--   [Modular](#modular)
-    -   [Audio source (things that can generate frequencies above 20Hz)](#audio-source)
-    -   [Audio processing (filter, amplifier, ring modulator, frequency shifter, waveshaper, distortion)](#audio-processing)
-    -   [Modulation source (LFOs, EGs, gates, triggers, random voltages, offset generators)](#modulation-source)
-    -   [Modulation processing (logic functions, sample and hold, slew limiter, comparator, inverter, quantizer)](#modulation-processing)
-    -   [Routing (mixer, switch, mult)](#routing)
-    -   [Audio effects (delays, DSP, phaser, pitchshifter)](#audio-effects)
-    -   [Other/utility (oscilloscope, lights, MIDI-to-CV, etc)](#otherutility)
-    -   [Full Voice](#full-voice)
--   [Standalone](#standalone)
+- [Modular](#modular)
+  - [Audio source (things that can generate frequencies above 20Hz)](#audio-source)
+  - [Audio processing (filter, amplifier, ring modulator, frequency shifter, waveshaper, distortion)](#audio-processing)
+  - [Modulation source (LFOs, EGs, gates, triggers, random voltages, offset generators)](#modulation-source)
+  - [Modulation processing (logic functions, sample and hold, slew limiter, comparator, inverter, quantizer)](#modulation-processing)
+  - [Routing (mixer, switch, mult)](#routing)
+  - [Audio effects (delays, DSP, phaser, pitchshifter)](#audio-effects)
+  - [Other/utility (oscilloscope, lights, MIDI-to-CV, etc)](#otherutility)
+  - [Full Voice](#full-voice)
+- [Standalone](#standalone)
+
 
 ## Modular
 
@@ -23,19 +24,19 @@ An awesome list of open source synthesizer projects.
 
 ### Modulation Source
 
--   Eurorack
+- Eurorack
 
-    -   LFO
+  - LFO
+    - [Swirls](https://github.com/ElectricMist/Swirls) : Tides in an 8hp footprint
+    - [Tides](https://github.com/pichenettes/eurorack/tree/master/tides) : Tidal modulator ([Mutable Instruments - Tides](https://mutable-instruments.net/modules/tides/))
+    - [Wobbler](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Advanced LFO ([TINRS - Wobbler](http://www2.thisisnotrocketscience.nl/eurorack/wobbler/))
 
-    -   [Swirls](https://github.com/ElectricMist/Swirls) : Tides in an 8hp footprint        -   [Tides](https://github.com/pichenettes/eurorack/tree/master/tides) : Tidal modulator ([Mutable Instruments - Tides](https://mutable-instruments.net/modules/tides/))
-    -   [Wobbler](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Advanced LFO ([TINRS - Wobbler](http://www2.thisisnotrocketscience.nl/eurorack/wobbler/))
+  - Sequencer
+    - [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
+    -[Turing Machine Mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([Music Thing Modular - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/)) 
 
-    -   Sequencer
-    -   [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-    -   [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
-
-    -   Envelope Generator / ADSR
-    -   [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
+  - Envelope Generator / ADSR
+    - [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
 
 ### Modulation Processing
 
@@ -45,13 +46,7 @@ An awesome list of open source synthesizer projects.
 
 ### Other/Utility
 
--   Eurorack
-
-    - Mixer
-
-    - [Trippe Attenuverter Mixer v2](https://github.com/ishkabbible/Triple_Attenuverter_Mixer_v2) : TAM is a three precision attenuator/attenuverter.
 ### Full Voice
 
 ## Standalone
-
--   [The Klangorium](https://github.com/hexagon5un/klangorium) - Hardware and tutorials for the Hackaday / Logic Noise Klangorium demo board
+- [The Klangorium](https://github.com/hexagon5un/klangorium) - Hardware and tutorials for the Hackaday / Logic Noise Klangorium demo board

--- a/README.md
+++ b/README.md
@@ -4,17 +4,16 @@ An awesome list of open source synthesizer projects.
 
 ## Contents
 
-- [Modular](#modular)
-  - [Audio source (things that can generate frequencies above 20Hz)](#audio-source)
-  - [Audio processing (filter, amplifier, ring modulator, frequency shifter, waveshaper, distortion)](#audio-processing)
-  - [Modulation source (LFOs, EGs, gates, triggers, random voltages, offset generators)](#modulation-source)
-  - [Modulation processing (logic functions, sample and hold, slew limiter, comparator, inverter, quantizer)](#modulation-processing)
-  - [Routing (mixer, switch, mult)](#routing)
-  - [Audio effects (delays, DSP, phaser, pitchshifter)](#audio-effects)
-  - [Other/utility (oscilloscope, lights, MIDI-to-CV, etc)](#otherutility)
-  - [Full Voice](#full-voice)
-- [Standalone](#standalone)
-
+-   [Modular](#modular)
+    -   [Audio source (things that can generate frequencies above 20Hz)](#audio-source)
+    -   [Audio processing (filter, amplifier, ring modulator, frequency shifter, waveshaper, distortion)](#audio-processing)
+    -   [Modulation source (LFOs, EGs, gates, triggers, random voltages, offset generators)](#modulation-source)
+    -   [Modulation processing (logic functions, sample and hold, slew limiter, comparator, inverter, quantizer)](#modulation-processing)
+    -   [Routing (mixer, switch, mult)](#routing)
+    -   [Audio effects (delays, DSP, phaser, pitchshifter)](#audio-effects)
+    -   [Other/utility (oscilloscope, lights, MIDI-to-CV, etc)](#otherutility)
+    -   [Full Voice](#full-voice)
+-   [Standalone](#standalone)
 
 ## Modular
 
@@ -24,19 +23,20 @@ An awesome list of open source synthesizer projects.
 
 ### Modulation Source
 
-- Eurorack
+-   Eurorack
 
-  - LFO
-    - [Swirls](https://github.com/ElectricMist/Swirls) : Tides in an 8hp footprint
-    - [Tides](https://github.com/pichenettes/eurorack/tree/master/tides) : Tidal modulator ([Mutable Instruments - Tides](https://mutable-instruments.net/modules/tides/))
-    - [Wobbler](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Advanced LFO ([TINRS - Wobbler](http://www2.thisisnotrocketscience.nl/eurorack/wobbler/))
+    -   LFO
 
-  - Sequencer
-    - [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
-    -
-    [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
-  - Envelope Generator / ADSR
-    - [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
+        -   [Swirls](https://github.com/ElectricMist/Swirls) : Tides in an 8hp footprint
+        -   [Tides](https://github.com/pichenettes/eurorack/tree/master/tides) : Tidal modulator ([Mutable Instruments - Tides](https://mutable-instruments.net/modules/tides/))
+        -   [Wobbler](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Advanced LFO ([TINRS - Wobbler](http://www2.thisisnotrocketscience.nl/eurorack/wobbler/))
+
+    -   Sequencer
+        -   [Tuesday](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Procedural Sequencer ([TINRS - Tuesday](http://www2.thisisnotrocketscience.nl/eurorack/tuesday/))
+        -
+        [Turing Machine mk2](https://github.com/TomWhitwell/TuringMachine) : Random Looping Sequencer ([MTM - Turing Machine mk2](https://www.thonk.co.uk/shop/turingmkii/))
+    -   Envelope Generator / ADSR
+        -   [Edgecutter](https://github.com/ThisIsNotRocketScience/Eurorack-Modules/tree/master/Production) : Visual envelope ([TINRS - Edgecutter](http://www2.thisisnotrocketscience.nl/eurorack/edgecutter/))
 
 ### Modulation Processing
 
@@ -49,4 +49,5 @@ An awesome list of open source synthesizer projects.
 ### Full Voice
 
 ## Standalone
-- [The Klangorium](https://github.com/hexagon5un/klangorium) - Hardware and tutorials for the Hackaday / Logic Noise Klangorium demo board
+
+-   [The Klangorium](https://github.com/hexagon5un/klangorium) - Hardware and tutorials for the Hackaday / Logic Noise Klangorium demo board


### PR DESCRIPTION
A few modules that I have built myself that I can confirm worked and some modules that are yet to be built.

modules added:
- Music Thing Modular mk2 - Turing Machine mk2
- Music Thing Modular mk2 - Turing Machine mk2 Volts Expander
- Music Thing Modular mk2 - Turing Machine mk2 Pulses Expander
- Music Thing Modular mk2 - Turing Machine mk2 Voltages Expander
- Music Thing Modular mk2 - Mikrophonie
- System80 - Jove
- Dave Hamara - Tripple Attenuverting Mixer v2

I would like to add in the mutable stuff as well but the pichenettes github page does not follow your "typical" github folder structure, so not quite sure how to add those in the categories currently setup. I am quite new to github and git in general so maybe others can chime in...?
